### PR TITLE
Revert "CHORE: remove caret from debug to prevent auto upgrade to malicious version"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "async": "^3.2.5",
         "body-parser": "^1.20.2",
         "config": "^3.3.9",
-        "debug": "4.3.4",
+        "debug": "^4.3.4",
         "deep-clone-merge": "^1.5.5",
         "express": "^4.18.2",
         "hmpo-logger": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "^3.2.5",
     "body-parser": "^1.20.2",
     "config": "^3.3.9",
-    "debug": "4.3.4",
+    "debug": "^4.3.4",
     "deep-clone-merge": "^1.5.5",
     "express": "^4.18.2",
     "hmpo-logger": "^7.0.1",


### PR DESCRIPTION


This reverts commit f8c98fcf0fc024ee4264a3cbbc8a5e981f76d3ec.